### PR TITLE
docs: align docs structure with v-onboarding

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
             { text: 'Options', link: '/api/options' },
             { text: 'Hooks', link: '/api/hooks' },
             { text: 'Events', link: '/api/events' },
-            { text: 'Render Props', link: '/api/render-props' },
+            { text: 'Slots', link: '/api/slots' },
             { text: 'CSS Variables', link: '/api/css-variables' }
           ]
         }

--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -73,7 +73,7 @@ Callback fired when the user exits the tour early. Receives the current step ind
 - **Type:** `(props: RenderProps) => ReactNode`
 - **Required:** No
 
-Render function for custom step UI. See [Render Props](/api/render-props) for details.
+Render function for custom step UI. See [Slots](/api/slots) for details.
 
 ```tsx
 <ROnboardingWrapper ref={wrapperRef} steps={steps}>

--- a/docs/api/slots.md
+++ b/docs/api/slots.md
@@ -1,12 +1,12 @@
-# Render Props
+# Slots
 
 r-onboarding provides render props for complete UI customization.
 
-## Default Render Prop
+## Default Slot
 
-The main render prop for customizing step appearance.
+The main slot for customizing step appearance.
 
-### Render Props
+### Slot Props
 
 | Prop | Type | Description |
 |------|------|-------------|


### PR DESCRIPTION
## Summary
  - Rename `api/render-props.md` to `api/slots.md` to match v-onboarding docs structure
  - Update all navigation links and cross-references
  - Docs structure is now identical between r-onboarding and v-onboarding (16 files each)

  ## Changes
  - `docs/api/render-props.md` → `docs/api/slots.md`
  - Updated `.vitepress/config.ts` sidebar link
  - Updated `api/props.md` cross-reference