### PR TITLE
fix: improve requestAnimationFrame mock for recursive calls

### DIFF
--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -8,12 +8,13 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
 }));
 
 // Mock requestAnimationFrame and cancelAnimationFrame
-global.requestAnimationFrame = vi.fn((callback) => {
-  return setTimeout(callback, 0);
-});
-global.cancelAnimationFrame = vi.fn((id) => {
+// Use direct function assignment instead of vi.fn() to ensure it works in recursive calls
+global.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+  return setTimeout(() => callback(performance.now()), 0) as unknown as number;
+};
+global.cancelAnimationFrame = (id: number): void => {
   clearTimeout(id);
-});
+};
 
 // Mock scrollIntoView which is not implemented in jsdom
 Element.prototype.scrollIntoView = vi.fn();


### PR DESCRIPTION
  ## Summary
  - Fix requestAnimationFrame mock to work correctly with recursive calls in CI environment
  - Use direct function assignment instead of vi.fn() wrapper

  ## Problem
  The previous mock using `vi.fn()` didn't persist correctly when called recursively from within a setTimeout callback, causing "requestAnimationFrame is not defined" errors in CI.